### PR TITLE
Simplify `report_time` and always use UTC

### DIFF
--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -9,7 +9,6 @@ use Exporter;           #core
 use JSON;               #cpan
 use POSIX;              #core
 use Term::ANSIColor;    #core
-use Time::Local;        #core
 use HTTP::Tiny;         #core
 
 our $VERSION = '1.4';
@@ -221,48 +220,30 @@ sub version {
 ##
 ## with special date formatting by request
 sub report_time {
-    my $option = shift;
-
-    #      0    1    2     3     4    5     6     7     8
-    #     sec  min  hour  mday  mon  year wday  yday  isdst
-    my @time             = localtime(time);
-    my $r_year           = $time[5] + 1900;
-    my $r_month          = sprintf( "%02d", $time[4] + 1 );
-    my $r_week           = sprintf( "%02d", ceil( $time[7] / 7 ) );
-    my $r_mday           = sprintf( "%02d", $time[3] );
-    my $r_hr             = sprintf( "%02d", $time[2] );
-    my $r_min            = sprintf( "%02d", $time[1] );
-    my $r_sec            = sprintf( "%02d", $time[0] );
-    my $gmt_offset_hours = ( timegm(@time) - timelocal(@time) ) / 60 / 60;
-    my $gmt_offset_mins = ( $gmt_offset_hours - int($gmt_offset_hours) ) * 60;
-    my $gmt_offset_str  = "";
-
-    if ( $gmt_offset_hours > 0 ) {
-        $gmt_offset_str = sprintf( "\+" . "%02d", $gmt_offset_hours ) . ":"
-            . sprintf( "%02d", $gmt_offset_mins );
-    }
-    elsif ( $gmt_offset_hours == 0 ) {
-        $gmt_offset_str = "";
-    }
-    elsif ( $gmt_offset_hours < 0 ) {
-        $gmt_offset_str = sprintf( "%03d", $gmt_offset_hours ) . ":"
-            . sprintf( "%02d", $gmt_offset_mins );
-    }
-
-    if ( $option eq "long" ) {
-        return
-              "$r_year" . "-"
-            . "$r_month" . "-"
-            . "$r_mday" . "T"
-            . "$r_hr:$r_min:$r_sec"
-            . "$gmt_offset_str";
-    }
-    elsif ( $option eq 'short' ) {
-        return "funtoo-$r_year.$r_week";
-    }
-    else {
-        return "no time";
-    }
+    my $format = shift;
+    my %formats = (
+        long => sub {
+            my @t = @_;
+            my $year = $t[5] + 1900;
+            my $mon  = $t[4] + 1;
+            my $day  = $t[3];
+            my $hour = $t[2];
+            my $min  = $t[1];
+            my $sec  = $t[0];
+            return sprintf '%04u-%02u-%02uT%02u:%02u:%02uZ',
+                $year, $mon, $day, $hour, $min, $sec;
+        },
+        short => sub {
+            my @t = @_;
+            my $year = $t[5] + 1900;
+            my $week = ceil(($t[7] + 1) / 7);
+            return sprintf 'funtoo-%04u-%02u',
+                $year, $week;
+        },
+    );
+    exists $formats{$format}
+        or return 'no time';
+    return $formats{$format}->(gmtime);
 }
 
 ##

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -7,7 +7,7 @@ use strict;
 use warnings;
 use Exporter;           #core
 use JSON;               #cpan
-use POSIX;              #core
+use POSIX qw(ceil);     #core
 use Term::ANSIColor;    #core
 use HTTP::Tiny;         #core
 

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -237,7 +237,7 @@ sub report_time {
             my @t = @_;
             my $year = $t[5] + 1900;
             my $week = ceil(($t[7] + 1) / 7);
-            return sprintf 'funtoo-%04u-%02u',
+            return sprintf 'funtoo-%04u.%02u',
                 $year, $week;
         },
     );


### PR DESCRIPTION
In an attempt to reduce the pain evident in this function around time zones, which I suspect #44 has run into, rewrite it while still returning the same formats, but always return it in UTC via `gmtime` with the `Z` suffix.

As an example, I live in New Zealand, which means that the week-of-year calculation if based on `localtime` will tick over for me before it does for the Americans.

I suggest that instead we do all our times in UTC to make it both conceptually simpler and easier to implement. If we do want to include the user's current time zone as part of the report, we could make that a separate datum, and retrieve it with `POSIX::strftime('%Z')`.

In passing, also fix a minor performance issue related to the `POSIX` module import.