### PR TITLE
Coerce numeric types for block device sizes

### DIFF
--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -421,6 +421,17 @@ sub get_filesystem_info {
     # by device name (e.g. "sda1")
     my $hash = transform_es_arrayref($data, 'name');
 
+    # coerce integer types on block device sizes
+    my @bds = (values %{ $hash->{blockdevices} });
+    while (my $bd = pop @bds) {
+        if (defined $bd->{size}) {
+            $bd->{size} += 0;
+        }
+        if (defined $bd->{children}) {
+            push @bds, values %{ $bd->{children} };
+        }
+    }
+
     return $hash;
 }
 

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -422,7 +422,7 @@ sub get_filesystem_info {
     my $hash = transform_es_arrayref($data, 'name');
 
     # coerce integer types on block device sizes
-    my @bds = (values %{ $hash->{blockdevices} });
+    my @bds = values %{ $hash->{blockdevices} };
     while (my $bd = pop @bds) {
         if (defined $bd->{size}) {
             $bd->{size} += 0;


### PR DESCRIPTION
Iterate through the `lsblk --json` data structure after it's reshaped for ElasticSearch consumption to coax all the "size" keys for each block device to have numeric values.

Should resolve #52.