### PR TITLE
Expand Makefile.PL to allow a full Perl dist, specify dependencies including minimum Perl version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Makefile
+MYMETA.json
+MYMETA.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 blib
+Funtoo-Report-*.tar.gz
 Makefile
 MYMETA.json
 MYMETA.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 blib
 Funtoo-Report-*.tar.gz
 Makefile
+Makefile.old
 MYMETA.json
 MYMETA.yml
 pm_to_blib

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+blib
 Makefile
 MYMETA.json
 MYMETA.yml
+pm_to_blib

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,4 +2,5 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     NAME            => 'Funtoo::Report',
     VERSION_FROM    => 'lib/Funtoo/Report.pm',
+    EXE_FILES       => ['funtoo-report'],
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,6 @@
+use 5.006;
+use strict;
+use warnings;
 use ExtUtils::MakeMaker;
 WriteMakefile(
     NAME            => 'Funtoo::Report',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,5 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
     NAME            => 'Funtoo::Report',
-    VERSION_FROM    => 'lib/Funtoo/Report.pm'
+    VERSION_FROM    => 'lib/Funtoo/Report.pm',
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,8 @@ use strict;
 use warnings;
 use ExtUtils::MakeMaker;
 WriteMakefile(
-    NAME            => 'Funtoo::Report',
-    VERSION_FROM    => 'lib/Funtoo/Report.pm',
-    EXE_FILES       => ['funtoo-report'],
+    NAME             => 'Funtoo::Report',
+    VERSION_FROM     => 'lib/Funtoo/Report.pm',
+    EXE_FILES        => ['funtoo-report'],
+    MIN_PERL_VERSION => '5.014',
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,4 +7,11 @@ WriteMakefile(
     VERSION_FROM     => 'lib/Funtoo/Report.pm',
     EXE_FILES        => ['funtoo-report'],
     MIN_PERL_VERSION => '5.014',
+    PREREQ_PM        => {
+        'Exporter'        => 0,
+        'HTTP::Tiny'      => 0,
+        'JSON'            => 0,
+        'POSIX'           => 0,
+        'Term::ANSIColor' => 0,
+    },
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,9 @@ WriteMakefile(
     EXE_FILES        => ['funtoo-report'],
     MIN_PERL_VERSION => '5.014',
     PREREQ_PM        => {
+        'autodie'         => 0,
+        'Carp'            => 0,
+        'English'         => 0,
         'Exporter'        => 0,
         'HTTP::Tiny'      => 0,
         'JSON'            => 0,

--- a/funtoo-report
+++ b/funtoo-report
@@ -24,7 +24,6 @@ use strict;                 #core
 use warnings;               #core
 use JSON;                   #cpan
 use Term::ANSIColor;        #core
-use lib "$ENV{PWD}/lib";    #core
 use Funtoo::Report;         #GIT
 use HTTP::Tiny;             #core
 

--- a/funtoo-report
+++ b/funtoo-report
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 ## Author : Joshua S. Day (haxmeister)
 ## Purpose : A anonymous funtoo data reporting tool

--- a/funtoo-report
+++ b/funtoo-report
@@ -20,6 +20,7 @@
 ## distribution on funtoo or wherever and the module can go
 ## in a more proper place
 
+use 5.014;
 use strict;                 #core
 use warnings;               #core
 use JSON;                   #cpan

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -3,6 +3,7 @@ package Funtoo::Report;
 ### Author : Joshua S. Day (haxmeister)
 ### purpose : functions for retrieving data on funtoo linux
 
+use 5.014;
 use strict;
 use warnings;
 use Exporter;           #core


### PR DESCRIPTION
Per a short discussion with @palica, these commits are an initial attempt to expand `Makefile.PL` and supporting files to allow building and installing both `Funtoo::Reporter` and the `funtoo-report` binscript with the Perl toolchain, independently of Funtoo:

```
$ perl Makefile.PL
$ make
# make install
```

On Funtoo (and most system installations of Perl), this would apply an appropriate path to the `perl` interpreter binary (`/usr/bin/perl`, usually) to the top of `funtoo-report`, and install it to `/usr/local/bin`, and the module `Funtoo::Reporter` to `/usr/local/lib[32,64]`.

It also means we can create standard tarball distributions of the module like so:

```
$ perl Makefile.PL
$ make
$ make dist
```

This produces a gzipped tarball, presently `Funtoo-Report-1.4.tar.gz`, in the project root. This can be installed with `cpan` or `cpanm` as part of the Perl toolchain.

As part of this, there's a specification in `Makefile.PL` of the modules required to run the tool, and also of the minimum Perl version required. As a starting point, I have set this to v5.14, the first stable verson in which `HTTP::Tiny` was a core module.

There is one backward incompatible change: because this method of building the module installs the libraries in a "known good" location, if it's used then there's no need for the `use lib "$PWD/lib"` to automatically add the current directory to the include path. This means that if we want to test `funtoo-report` straight from the project root without installing it, we need to include an `-I` option to specify that it should load the local version of the library from source:

```
$ perl -Ilib funtoo-report show-json
```

I'm not sure how all of the above interacts with the Funtoo ebuild system.

If all of this applies cleanly to Funtoo build processes and the developers' workflows, it opens up the possibility of putting tests in the `t` directory to test basic functionality of the module with just a `make test` call, and these tests can be automatically run when the module is installed with `cpan` or `cpanm`. It also opens up the long-term possibility of adding the module to CPAN if that's ever desirable, and of generating manual pages for both the script and the module automatically from POD.

I don't expect this pull request to necessarily be merged as-is; I'd like to know how well any/all of this is going to work with what we have first.