### PR TITLE
Re-work get_all_installed_pkg()

### DIFF
--- a/funtoo-report
+++ b/funtoo-report
@@ -128,7 +128,6 @@ sub report_from_config {
         'kernel-info'    => \&Funtoo::Report::get_kernel_info,
         'kit-info'       => \&Funtoo::Report::get_kit_info,
         'profile-info'   => \&Funtoo::Report::get_profile_info,
-        'version-info'   => \&Funtoo::Report::get_version_info,
         'world-info'     => \&Funtoo::Report::get_world_info,
         'installed-pkgs' => \&Funtoo::Report::get_all_installed_pkg,
         'hardware-info'  => \&Funtoo::Report::get_hardware_info,


### PR DESCRIPTION
Reworked get_all_installed_pkg() to get the data without the use of
equery and to make use of a pure hash datastructure. Now includes the
SLOT used for each package, though this addition has some speed
consequences due to the complexity of the hash.

Removed get_version_info() since it is likely redundant now that
searching can be performed easier on the ElasticSearch website.