### PR TITLE
Define a custom User-Agent for the HTTP submit

### DIFF
--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -45,7 +45,8 @@ sub send_report {
     );
 
     # create a new HTTP object
-    my $http = HTTP::Tiny->new();
+    my $agent = sprintf '%s/%s', __PACKAGE__, $VERSION;
+    my $http = HTTP::Tiny->new(agent => $agent);
 
     # send report and capture the response from ES
     my $response = $http->request( 'POST', $url, \%options );


### PR DESCRIPTION
Just to be polite, set the `User-Agent` to something custom so that requests from this script can be quickly identified in server logs.

In an Apache HTTPD log, the requests look something like this:

```
192.0.2.1 - - [12/Mar/2018:09:58:07 +1300] "POST / HTTP/1.1" 201 23514 "-" "Funtoo::Report/1.4"
```

We can add more information to the user agent if we want, such as an URL, but I think the name and version of the application is sufficient.

I have tested this submits correctly from my test VM.