### PR TITLE
Re-work get_all_installed_pkg, etc. for release

### DIFF
--- a/funtoo-report
+++ b/funtoo-report
@@ -135,6 +135,7 @@ sub report_from_config {
         'kernel-info'    => \&Funtoo::Report::get_kernel_info,
         'kit-info'       => \&Funtoo::Report::get_kit_info,
         'profile-info'   => \&Funtoo::Report::get_profile_info,
+        'version-info'   => \&Funtoo::Report::get_version_info,
         'world-info'     => \&Funtoo::Report::get_world_info,
         'installed-pkgs' => \&Funtoo::Report::get_all_installed_pkg,
         'hardware-info'  => \&Funtoo::Report::get_hardware_info,


### PR DESCRIPTION
-Re-worked get_all_installed_pkg to use the old data style.
-Re-worked that, get_world_info, and the re-introduced get_version_info
 to work together via caller in order to avoid more tiny subs; also
 added error-handling where appropriate.
-Re-worked the front-end script in light of those changes.