### PR TITLE
Normalized error-handling, ran perltidy

### DIFF
--- a/funtoo-report
+++ b/funtoo-report
@@ -11,25 +11,26 @@
 ## dev-perl/JSON-2.900.0
 ##
 ## also from Github
-## The accompanying "Report.pm" module 
+## The accompanying "Report.pm" module
 
 use 5.014;
-use strict;                 #core
-use warnings;               #core
-use Getopt::Long;           #core
-use JSON;                   #cpan
-use Term::ANSIColor;        #core
-use Funtoo::Report;         #GIT
-use HTTP::Tiny;             #core
+use strict;             #core
+use warnings;           #core
+use Getopt::Long;       #core
+use JSON;               #cpan
+use Term::ANSIColor;    #core
+use Funtoo::Report;     #GIT
+use HTTP::Tiny;         #core
 
 my %es_config = (
     node  => 'http://elk.liguros.net:9200',
     index => Funtoo::Report::report_time('short'),
-    type  => 'report');
+    type  => 'report'
+);
 
 # parse options
 my $debug = 0;
-GetOptions('debug|d' => \$debug)
+GetOptions( 'debug|d' => \$debug )
     or die "Error in command line arguments\n";
 
 # dispatch table of script actions
@@ -52,9 +53,10 @@ my %actions = (
 
     # generate and send JSON report, and print URL
     'send' => sub {
+
         # get the entire report
         my %report = report_from_config();
-        Funtoo::Report::send_report(\%report, \%es_config, $debug);
+        Funtoo::Report::send_report( \%report, \%es_config, $debug );
     },
 
     # update configuration file
@@ -65,7 +67,7 @@ my %actions = (
 );
 
 # pull action from script arguments if possible
-if (length (my $action = shift @ARGV)) {
+if ( length( my $action = shift @ARGV ) ) {
     exists $actions{$action}
         or die "Unknown action '$action'\n";
     $actions{$action}->();
@@ -164,7 +166,7 @@ sub report_from_config {
     ## adding version number to report
     #
     $hash{'funtoo-report'}{'version'} = Funtoo::Report::version();
-    
+
     ## adding any non fatal errors to the report
     #
     $hash{'errors'} = Funtoo::Report::errors();

--- a/funtoo-report
+++ b/funtoo-report
@@ -169,7 +169,7 @@ sub report_from_config {
 
     ## adding any non fatal errors to the report
     #
-    $hash{'errors'} = Funtoo::Report::errors();
+    $hash{'funtoo-report'}{'errors'} = Funtoo::Report::errors();
 
     return %hash;
 }

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -1043,7 +1043,7 @@ sub push_error {
     my $parent        = ( caller 1 )[3];
     my $line          = ( caller 0 )[2];
     print {*STDERR} "$parent: $error_message at line $line\n";
-    push @errors, "$parent: $error_message";
+    push @errors, "$parent: $error_message at line $line";
     return;
 }
 

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -329,7 +329,6 @@ sub get_hardware_info {
 ## of making calls to external tools
 ##
 sub get_net_info {
-    use autodie qw< :io >;
 
     my $interface_dir = '/sys/class/net';
     my $pci_ids       = '/usr/share/misc/pci.ids';

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -18,7 +18,7 @@ our $VERSION = '1.4';
 
 ### getting some initialization done:
 my $config_file = '/etc/funtoo-report.conf';
-my %errors;                        # for any errors that don't cause a die
+my @errors;                        # for any errors that don't cause a die
 
 ##
 ## generates report, creates user agent, and sends to elastic search
@@ -240,7 +240,7 @@ sub version {
 ## reporting errors
 ##
 sub errors {
-    return \%errors;
+    return \@errors;
 }
 
 ## returns a long date string for the report body or
@@ -1040,10 +1040,10 @@ sub get_y_or_n {
 ## *STDERR
 sub push_error {
     my $error_message = shift;
-    my $parent        = ( caller 0 )[3];
+    my $parent        = ( caller 1 )[3];
     my $line          = ( caller 0 )[2];
     print {*STDERR} "$parent: $error_message at line $line\n";
-    push @{ $errors{$parent} }, $error_message;
+    push @errors, "$parent: $error_message";
     return;
 }
 


### PR DESCRIPTION
-Converted error-handling to primarily use push_error(), with the
exception of errors that are clearly meant to be kept local, like bad
configuration files.
-Adjusted push_error() to now include the line number, similar to
carp().
-Ran both files through perltidy.
-Removed extraneous instance of autodie.