### PR TITLE
Add 'version' arg to print script/module versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Funtoo anonymous data reporting tool usage:
 funtoo-report send              Send the report to funtoo's data collection
 funtoo-report show-json         Show the output that will be sent, in JSON format
 funtoo-report help              Show this help list
+funtoo-report version           Show Funtoo::Report distribution version
 funtoo-report config-update     Generate, reconfigure or update the config file /etc/funtoo-report.conf
 
 Output can be ommitted by modifying the /etc/funtoo-report.conf file
@@ -28,6 +29,10 @@ Output can be ommitted by modifying the /etc/funtoo-report.conf file
 **help shows you the same output:**
 
 'funtoo-report help'
+
+**version shows you the script and module version numbers; ideally they should match:**
+
+'funtoo-report version'
 
 **To see what data the report is generating use the show-json option:**
 

--- a/funtoo-report
+++ b/funtoo-report
@@ -66,6 +66,13 @@ my %actions = (
 
     # show script help
     'help' => \&show_help,
+
+    # print script and module versions
+    'version' => sub {
+        printf "funtoo-report: %s\nFuntoo::Report: %s\n",
+            $VERSION,
+            Funtoo::Report::version(),
+    },
 );
 
 # pull action from script arguments if possible
@@ -104,6 +111,11 @@ sub show_help {
     print "funtoo-report help";
     print color('reset');
     print " \t\t Show this help list\n";
+
+    print color('bold blue');
+    print "funtoo-report version";
+    print color('reset');
+    print " \t\t Show script and module version\n";
 
     print color('bold');
     print "\nOutput can be ommitted by modifying ";
@@ -186,7 +198,7 @@ funtoo-report - An anonymous Funtoo data reporting tool
 
 =head1 USAGE
 
-    funtoo-report [-d|--debug] (config-update|show-json|send|help)
+    funtoo-report [-d|--debug] (config-update|show-json|send|help|version)
 
 =head1 DESCRIPTION
 
@@ -216,6 +228,10 @@ Generate the system report and send it to the hardcoded ElasticSearch server.
 =item C<help>
 
 Print usage help.
+
+=item C<version>
+
+Print script and module versions.
 
 =back
 


### PR DESCRIPTION
When run as 'funtoo-report version', this prints both the script and module versions to standard out. Ideally, they should be the same.

This should resolve GitHub issue #77.

```
$ perl -Ilib funtoo-report version
funtoo-report: 2.0.0-dev
Funtoo::Report: 2.0.0-dev
```