### PR TITLE
Added a function to check latest version in GIT

### DIFF
--- a/funtoo-report
+++ b/funtoo-report
@@ -133,7 +133,7 @@ sub show_help {
 sub report_from_config {
     my %config = Funtoo::Report::user_config();    # fetch/parse the user config
     my %hash;
-
+    
     # look for a UUID in the config file and
     # if it's not there, add one
     if ( exists $config{'UUID'} ) {
@@ -169,6 +169,7 @@ sub report_from_config {
         # hash table to the report
         $hash{$report} = $sections{$report}->();
     }
+    
     ## adding UUID to the body of the report
     #
     $hash{'funtoo-report'}{'UUID'} = $config{'UUID'};

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -14,7 +14,7 @@ use List::Util qw(any);            #core
 use Term::ANSIColor;               #core
 use Time::Piece;                   #core
 
-our $VERSION = '2.0.10-dev';
+our $VERSION = '2.0.0-dev';
 
 ### getting some initialization done:
 my $config_file = '/etc/funtoo-report.conf';

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -14,12 +14,14 @@ use List::Util qw(any);            #core
 use Term::ANSIColor;               #core
 use Time::Piece;                   #core
 
-our $VERSION = '2.0.0-dev';
+our $VERSION = '2.0.10-dev';
 
 ### getting some initialization done:
 my $config_file = '/etc/funtoo-report.conf';
 my @errors;                        # for any errors that don't cause a die
-
+my %fr_config = (
+    'git_url' => 'https://api.github.com/repos/haxmeister/funtoo-reporter/releases/latest',
+);
 ##
 ## generates report, creates user agent, and sends to elastic search
 ##
@@ -86,6 +88,56 @@ sub send_report {
         push_error('Expected location for created resource');
     }
 }
+
+##
+## Check available version in github.com and warn user if a new one
+## is available.. and add that info to error report
+sub latest_git_version{
+    my $git_url = shift;
+    my $latest_version;
+    
+    # make a json object we can use to decode the response
+    my $json = JSON->new->allow_nonref;
+    
+    # fetch the url     
+    my $response = HTTP::Tiny->new->get($git_url);
+
+    # if the url responds successfully, 
+    if ($response->{success}) {
+        
+        # decode the response
+        my $json_response = $json->decode($response->{content});
+        
+        # extract the version from the response and remove the preceding 'v'
+        if ($json_response->{'tag_name'} =~ /^v(.*)/msx){
+            my $latest_version = $1;
+            
+            # if the version in git matches the current version
+            if (index($VERSION, $latest_version ) != -1){
+                 return;
+            }
+            else{
+                # if it doesn't match, report the error
+                print "A newer version of funtoo-reporter is available at $json_response->{url}\n";
+                push_error("user version $VERSION does not match git version $latest_version");
+                
+                return;
+            }
+        }
+        else{
+            # If the tag_name doesn't start with a 'v', report the error
+            push_error('latest version tag in GIT does not match the expected format ');
+            return;
+        }
+    }
+    else{
+        # if the http request failed, report the error
+        push_error ("$response->{status} $response->{reason} $response->{url} \n");
+        return;
+    }
+    return;
+}
+
 
 ##
 ## finds the config file in /etc/funtoo-report.conf and loads its contents
@@ -234,6 +286,8 @@ sub add_uuid {
 ## reporting version number
 ##
 sub version {
+    # checking we have the latest version
+    latest_git_version($fr_config{git_url});
     return $VERSION;
 }
 


### PR DESCRIPTION
Per issue #83  this adapts the ```version()``` sub to call a new function called ```latest_git_version()``` It is passed the location of our GIT api to the latest version json.. responds if the versions don't match and error reports it.

