### PR TITLE
Add Bash completion for funtoo-report options

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,4 +3,5 @@ MANIFEST
 README.md
 funtoo-report
 lib/Funtoo/Report.pm
+share/bash-completion/funtoo-report.bash
 LICENSE

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ installed-pkgs:y
 hardware-info:y
 ```
 
+### Shell completion
+
+Options completion for GNU bash is available in
+`share/bash-completion/funtoo-report.bash`:
+
+    bash$ source share/bash-completion/funtoo-report.bash
+
 ### Uninstall
 We are sorry to see you go!
 

--- a/share/bash-completion/funtoo-report.bash
+++ b/share/bash-completion/funtoo-report.bash
@@ -1,0 +1,15 @@
+# Complete option names, or complete filenames/dirs as normal
+# bashdefault requires Bash >=3.0
+[ -n "$BASH_VERSINFO" ] || return
+(( BASH_VERSINFO[0] >= 3 )) || return
+complete -W '
+    --config
+    --update-config
+    --list-config
+    --show-json
+    --send
+    --verbose
+    --debug
+    --help
+    --version
+' -o bashdefault -o default funtoo-report


### PR DESCRIPTION
If completing something that doesn't look like an `--option`, revert to Bash's defaults (file and directory completion).

Include mention in `README.md`.

This should deal with GitHub issue #120.