### PR TITLE
Add rough approach to Changelog with past versions

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,112 +2,22 @@ Revision history for Funtoo-Report
 
 3.0.0	2018-04-19
 
- - Sort keys in generated configuration file
- - Make a few corrections to script leading comment
- - Use Time::Piece to massively simplify report_time
- - Place get_boot_dir_info() closedir more logically
- - Use lexical filehandles instead of barewords
- - Use arg unpack not repeated shift in send_report
- - Put lsblk command in variable to dedupe
- - Put lspci command in variable to dedupe
- - Put epro command in variable to dedupe
- - Simplify an interpolated string
- - Adjust formatting and indent for a comment
- - Use actual undef, not string "undef" for hash work
- - Add $VERSION to funtoo-reporter script
- - Add explicit package to funtoo-reporter script
- - Switch to development version and ELK settings
- - Remove two no-op else-next conditions
- - Remove unused @hardware_list variable
- - Use separate filehandles within add_uuid()
- - Reimplement get_kernel_info to read fewer files
- - Refactor get_mem_info to parse as we read
- - Use more idiomatic numeric coerce for memory vals
- - Add explicit close for meminfo filehandle
- - Add -dev suffix to README.md version
- - Add the beginnings of some POD documentation
- - Remove autodie from Makefile.PL dependencies list
- - creating daily indexing for ES
- - Remove POSIX dependency
- - Add 'version' arg to print script/module versions
- - Short-circuit submission if UUID is obviously bad
- - Mention required version for List::Util in POD
- - Added a function to check latest version in GIT
- - restored version number after testing
- - Add check-version option and modified other files to reflect this
-   change
- - now reporting to funtoo or fundev with version number in index
-   respectively
- - added version in index string
- - formatting date string for index
- - Removed the version check function and remnants
- - Update Report.pm
- - Adjusted USAGE and finished Getopt integration
- - Remove previous cmd line with outdate opt format
- - Correct typo
- - Amend POD detail to reflect new option invocation
- - Adjusted short option for config update in anticipation of
-   alternative configuration option
- - Changed hard-coded http to https and bumped the version
- - Correct short letter for --config-update option
- - Update README.md to reflect new options syntax
- - Correct a spelling error in README.md
- - Update reference to old --config-update subcommand
- - Allow specifying alt path to config file
- - Change option-handling and add priority levels
- - Added a quick check for extra invalid options
- - Specify Pod::Usage as a Makefile.PL dependency
- - Update README.md option docs from POD
- - Bring version numbers back into parallel
- - Update POD dependencies for script and module
- - Add Time::Piece dependency to Makefile.PL
- - Update protocol URL in module POD
- - Combine dummy dev hash creation in get_net_info()
- - Combine hashref declaration in get_net_info()
- - Correct short --list-config: -n to -l
- - Add HTTP::Tiny HTTPS depends to module POD
- - Create .travis.yml
- - Alternative form of get_all_installed_pkg()
- - Removing apparently nonsensical line
- - Add a separate world-info section
- - Initial work on restructuring filesystem info
- - added device-count
- - adjusted to coerce numbers for filesystem sizes
- - added tran type ... #94
- - minor device count modification #94
- - switched to a datastructure of totals
- - adapting for null fstypes found on my container
- - cleaned up, good candidate issue #94
- - failures from null values fixed finally?
- - added size and count of fstypes #94
- - Convert filesystem and memory to GB
- - Add +=0 to coerce the new values to pure numbers instead of strings
- - #94 with renamed unreported and swapspace
- - #94 restoring GB in meminfo
- - changes in options
- - patching error from null fstypes that are not children
- - patch missing sigil
- - Adding first try to implement #102 - README.md and POD version
-   update working - not working: bumping our $VERSION, please fix
- - #105 now recursive, should follow children and avoid null errors
- - Changed to pure shell, regexes working
- - Correcting usage to imply mandatory arguments
- - picking up nulls
- - Formatting for GB
- - Skips virtual devices as requested by #106
- - Add "describe" option as per request in #102
- - Fixing '.' in version output.
- - Added --verbose option as per #103
- - Updated README to reflect --verbose
- - changing address of ES
- - Updating documentation that references the ES URL
- - Updated URLs to make merging with develop easier
- - #107 field limit fix
- - Add comment with version to config as per #112
- - set verbose output and clean up
- - Revert "Update Report.pm"
- - adding POD for new function
- - Perltidy + start of additional documentation
+Breaking changes:
+  - changing subcommands to options (eg. send => --send|-s)
+
+Changes:
+  - support for alternate config file
+  - automated travis-ci testing of develop branch
+  - alternative way of get_all_installed_pkg
+  - removing veth network devices information
+  - version bumping script for internal use and for use in ebuilds
+  - added verbose option
+  - timestamp is now added to the config file upon updating or creation
+  - auto-fixing ES field limits
+
+Bug fixes:
+  - filesystems information fixes (ignoring usb mounts)
+
 
 2.0.1	2018-03-21
   Bug fixes:

--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 Revision history for Funtoo-Report
 
+Next-release 2018-xx-yy
+
+Changes:
+  - adding bash-completion for the tool
+  - reporting how long each section took to generate
+  - added Changes file to track changed code and added features
+  - added config check logic, that will check configuration file for errors
+
 3.0.0	2018-04-19
 
 Breaking changes:

--- a/Changes
+++ b/Changes
@@ -110,8 +110,8 @@ Revision history for Funtoo-Report
  - Perltidy + start of additional documentation
 
 2.0.1	2018-03-21
-
- - Switch to HTTPS URL, add Makefile.PL depend spec
+  Bug fixes:
+    - Switch to HTTPS URL, add Makefile.PL depend spec
 
 2.0.0	2018-03-17
 
@@ -120,132 +120,72 @@ Revision history for Funtoo-Report
  - Changed error-reporting to a flattened array
  - Added line numbers to @errors
  - Relocating errors to the funtoo-report hash
- - Update README.md
- - Update Report.pm
 
 1.4	2018-03-17
+  Breaking changes:
+    - moving /etc/report.conf => /etc/funtoo-report.conf
+    - cpu-info, mem-info, chassis-info, filesystem-info, networking-info combined into hardware-info (backend)
+    - Coerce numeric types for block device sizes (backend)
 
- - For issue #27 now generates a conf and also is converted to use
-   /etc/funtoo-report.conf
- - Update funtoo-report
- - simple error fix
- - added video card data to hardware-info
- - hardware listings should no longer contain special chars issue #43
- - added filesystem information
- - Update Report.pm
- - added netowrk interface info per issue #37
- - removed extra hash layer in networking section
- - get_kit_info function no longer needs to parse ego output
- - Re-wrote get_y_or_n
- - Correct a hash key I accidentally made plural
- - Remove JSON substitutions in get_filesystem_info()
- - Translate block device arrayrefs to hashrefs
- - Replaced ES module with the core module HTTP::Tiny for issue #42
- - Add --bytes (-b) to lsblk call to get byte sizes
- - for issue #47 replaced array items with slot number hashes
- - combined hardware information into a complete structure issue #47
- - Update README.md
- - Correct formatting error in `equery` output
- - Rewrite report_time() with UTC everywhere
- - Specify imported functions for `POSIX` module
- - Date format correction
- - Don't retrieve lspci output on module load
- - Factor out arrayref transform into separate sub
- - Correct a comment about traversal type
- - Coerce numeric types for block device sizes
- - Remove unneeded parens
- - Replace `transform_es_arrayref` with simple method
- - with code to reveal the response from ES
- - Add trail comma to last line of Makefile.PL args
- - Add binscript to Makefile.PL EXE_FILES
- - Ignore Makefile.PL build artifacts
- - Use magic #!perl shebang for binscript
- - Ignore some `make` artifact files
- - Remove `use lib` from binscript
- - Add version, strict, and warnings to Makefile.PL
- - Ignore built distribution tarballs
- - Specify minimum Perl of v5.14
- - Specify module dependencies in Makefile.PL
- - Ignore old Makefiles
- - Remove comment referring to removed module
- - Add three more dependencies to Makefile.PL
- - sending report now returns a URL to that data, also changed back the
-   shebang to normal
- - just fixing credits
- - Add comments, examples for `report_time` formats
- - Use English variable names throughout module
- - Promote `Carp` import to package scope
- - Realign `use` comments
- - Remove unneeded sub exports
- - Re-work get_all_installed_pkg()
- - Add dependency on List::Util >=v1.33
- - Add some HTTP error handling and output
- - Add Getopt::Long with a --debug/-d flag
- - Skip package DB dirs beginning with -MERGING-
- - Lowercase a comment
- - Refactor script actions with dispatch table
- - added error section for issue #58
- - Define a custom User-Agent for the HTTP submit
- - Adjust hash structure and error-handling
- - adjusting new function
- - Re-work get_all_installed_pkg, etc. for release
- - switch to elk instead of elk2
- - tweaking data structure for original ES
- - Correct documented config file path
- - Correct and rewrap a mis-wrapped README paragraph
- - Correct another mis-wrapped README paragraph
- - Mention -d/--debug option in README.md
- - Trivial comment fixes
- - Make comment refs to `lspci` calls consistent
- - Correct comment description of short date format
+  Changes:
+  - replaced Search::Elasticsearch with HTTP::Tiny
+  - ability to update/generate configuration file
+  - added reporting on:
+    - sound cards
+    - video cards
+    - filesystem information
+      - expressed in bytes
+    - network cards
+  - configuration file generation - re-write of yes_or_no function
+  - translated block device arrayrefs to hashrefs
+  - report time now with UTC everywhere
+  - index name funtoo-2018-01 => funtoo-2018.01
+  - factor out arrayref transform into separate sub for filesystem-info
+  - replace `transform_es_arrayref` with simple method
+  - added code to reveal the response from ES
+  - expanded Makefile.PL to allow a full Perl dist, specified dependencies including minimum Perl version
+  - sending report now returns a URL to that data
+  - use English variable names throughout module
+  - added some HTTP error handling and output
+  - added Getopt::Long with a --debug/-d flag
+  - added error section in report
+  - defined a custom User-Agent for the HTTP submit
+  - adjusted hash structure and error-handling
 
-1.3	2018-02-18
+  Bug fixes:
+    - lots of small bugfixes in readme and comments
 
- - Delete README.md
- - Create README.txt
- - Update Report.pm
- - Update report
- - Added UUID, fixed config file fail safes
- - Fix profiles to remove shortname key
- - fixes cpu-info to show siblings instead of cores, numerical instead
-   of strings
- - removed /n from id
- - Added function to send the report, also shortened the config file
-   algorythm
- - no change
- - set cpu-info to count processors from file
- - now reporting world file again
- - datestamp is back
- - added versioning and removed trailing space from UUID
- - changing timestamp to epochtime in seconds
- - Just added some notes to make it easier to follow
- - added installed packages, added conf file generator, also chassis
-   info
- - Rename README.txt to README.md
- - Update README.md
- - Added the full list of chassis possibilities from www.dmtf.org
-   official provider of these docs
- - update readme with install instructions for now
- - change layout of the project and add Funtoo:: before the Report
-   module
- - add Makefile.PL and MANIFEST
- - commenting out use of lib folder as we will have it in our perl
-   install
- - forgot to rename file
- - update manifest
- - Updating README and preparing for release
- - update readme
- - changed help
- - moved UUID to the body of the report and changed ES header to report
-   a blank string as _ID
- - Added credits in comments
- - Create License
- - add LICENSE file once it gets added to the repo
- - update Readme
- - Addressed issue #31, added dynamic index name by date and fancy date
-   format for the report body
- - Update funtoo-report
- - added leading 0 to timestamp
- - fix for offset when GMT+x
- - remove CPAN ref
- - fix typo in glibc version
+1.3	2018-02-17
+  Breaking changes:
+    - changing the timestamp format (breaking change from the backend view)
+    - changing _type from user to report (backend)
+
+  Changes:
+    - changing report index to funtoo-yyyy-ww format
+
+  Bug fixes:
+    - fix typo in glibc version reporting
+
+1.2	2018-02-14
+  Breaking changes:
+    - changing layout of modules modules/Report.pm => lib/Funtoo/Report.pm
+    - renaming report file to funtoo-report
+
+  Changes:
+    - adding basic MANIFEST and Makefile.PL
+
+1.1	2018-01-23
+  - ability to show json data structure that would be submitted to the Elasticsearch instance
+  - a unique UUID random identifier is generated according to RFC4122
+  - timestamp is recorded as part of report
+  - the tool can generate info about:
+    - CPU, memory, running kernel, kernels in /boot directory (kernel, vmlinuz, bzImage)
+    - chassis info
+    - packages in @world set, Funtoo profiles, Funtoo kits
+    - all installed packages
+    - and is specifically reporting versions of:
+      - portage, ego, python, gcc, glibc
+    - funtoo-report version
+  - ability to send data reports to Elasticsearch instance
+  - configuration file for report sections
+  - ability to generate configuration file if none exists

--- a/Changes
+++ b/Changes
@@ -1,0 +1,295 @@
+Revision history for Funtoo-Report
+
+3.0.0	2018-04-19
+
+ - Sort keys in generated configuration file
+ - Make a few corrections to script leading comment
+ - Use Time::Piece to massively simplify report_time
+ - Place get_boot_dir_info() closedir more logically
+ - Use lexical filehandles instead of barewords
+ - Use arg unpack not repeated shift in send_report
+ - Put lsblk command in variable to dedupe
+ - Put lspci command in variable to dedupe
+ - Put epro command in variable to dedupe
+ - Simplify an interpolated string
+ - Adjust formatting and indent for a comment
+ - Use actual undef, not string "undef" for hash work
+ - Adjust formatting and indent for a comment
+ - Add $VERSION to funtoo-reporter script
+ - Add explicit package to funtoo-reporter script
+ - Switch to development version and ELK settings
+ - Remove two no-op else-next conditions
+ - Remove unused @hardware_list variable
+ - Use separate filehandles within add_uuid()
+ - Reimplement get_kernel_info to read fewer files
+ - Refactor get_mem_info to parse as we read
+ - Use more idiomatic numeric coerce for memory vals
+ - Add explicit close for meminfo filehandle
+ - Add -dev suffix to README.md version
+ - Add the beginnings of some POD documentation
+ - Remove autodie from Makefile.PL dependencies list
+ - creating daily indexing for ES
+ - Remove POSIX dependency
+ - Perl::Tidy run over funtoo-report
+ - Add 'version' arg to print script/module versions
+ - Perl::Tidy run
+ - Short-circuit submission if UUID is obviously bad
+ - Mention required version for List::Util in POD
+ - Added a function to check latest version in GIT
+ - restored version number after testing
+ - Add check-version option and modified other files to reflect this
+   change
+ - now reporting to funtoo or fundev with version number in index
+   respectively
+ - added version in index string
+ - formatting date string for index
+ - Removed the version check function and remnants
+ - perltidy
+ - Update Report.pm
+ - Adjusted USAGE and finished Getopt integration
+ - Remove previous cmd line with outdate opt format
+ - Correct typo
+ - Amend POD detail to reflect new option invocation
+ - Adjusted short option for config update in anticipation of
+   alternative configuration option
+ - Changed hard-coded http to https and bumped the version
+ - Bump version in the other three places
+ - Correct short letter for --config-update option
+ - Update README.md to reflect new options syntax
+ - Correct a spelling error in README.md
+ - Update reference to old --config-update subcommand
+ - Allow specifying alt path to config file
+ - Change option-handling and add priority levels
+ - Added a quick check for extra invalid options
+ - Specify Pod::Usage as a Makefile.PL dependency
+ - Update README.md option docs from POD
+ - Bring version numbers back into parallel
+ - Update POD dependencies for script and module
+ - Add Time::Piece dependency to Makefile.PL
+ - Update protocol URL in module POD
+ - Combine dummy dev hash creation in get_net_info()
+ - Combine hashref declaration in get_net_info()
+ - Bump version number in module POD
+ - Correct short --list-config: -n to -l
+ - Add HTTP::Tiny HTTPS depends to module POD
+ - Create .travis.yml
+ - Alternative form of get_all_installed_pkg()
+ - Removing apparently nonsensical line
+ - Merge branch 'alternative-getall' of
+   https://github.com/haxmeister/funtoo-reporter into alternative-getall
+ - Create .travis.yml
+ - Add a separate world-info section
+ - Preparing to merge to develop
+ - Initial work on restructuring filesystem info
+ - added device-count
+ - adjusted to coerce numbers for filesystem sizes
+ - added tran type ... #94
+ - minor device count modification #94
+ - switched to a datastructure of totals
+ - adapting for null fstypes found on my container
+ - tweaks
+ - cleaned up, good candidate issue #94
+ - failures from null values fixed finally?
+ - added size and count of fstypes #94
+ - tweaks
+ - tweaks again
+ - Create .travis.yml
+ - Convert filesystem and memory to GB
+ - Add +=0 to coerce the new values to pure numbers instead of strings
+ - #94 with renamed unreported and swapspace
+ - Merge branch 'feature/filesystems' of
+   https://github.com/haxmeister/funtoo-reporter into
+   feature/filesystems
+ - #94 restoring GB in meminfo
+ - Preparing to merge to develop
+ - changes in options
+ - Minor corrections + perltidy
+ - patching error from null fstypes that are not children
+ - patch missing sigil
+ - Ran perltidy
+ - Update Report.pm
+ - Adding first try to implement #102 - README.md and	POD version
+   update working - not working: bumping our $VERSION, please fix
+ - #105 now recursive, should follow children and avoid null errors
+ - Changed to pure shell, regexes working
+ - Correcting usage to imply mandatory arguments
+ - picking up nulls
+ - Formatting for GB
+ - Added support for alpha/beta/rc stages alongside normal bumps
+ - Skips virtual devices as requested by #106
+ - Add "describe" option as per request in #102
+ - Fixing '.' in version output.
+ - Added --verbose option as per #103
+ - Updated README to reflect --verbose
+ - changing address of ES
+ - Updating documentation that references the ES URL
+ - Updated URLs to make merging with develop easier
+ - #107 field limit fix
+ - #107 repairing merge mess
+ - Add comment with version to config as per #112
+ - set verbose output and clean up
+ - Update Report.pm
+ - Revert "Update Report.pm"
+ - Update Report.pm
+ - adding POD for new function
+ - Perltidy + start of additional documentation
+ - Bumping the version to 3.0.0 in preparation for new major release
+
+2.0.1	2018-03-21
+
+ - Switch to HTTPS URL, add Makefile.PL depend spec
+ - Bump version number
+
+2.0.0	2018-03-17
+
+ - Normalized error-handling
+ - Ran Report.pm and funtoo-report through perltidy
+ - Removing old instance of autodie
+ - Changed error-reporting to a flattened array
+ - Added line numbers to @errors
+ - Relocating errors to the funtoo-report hash
+ - Update README.md
+ - Update Report.pm
+
+1.4	2018-03-17
+
+ - For issue #27 now generates a conf and also is converted to use
+   /etc/funtoo-report.conf
+ - Update funtoo-report
+ - simple error fix
+ - Now shows sound card data issue #36 and ran perltidy
+ - added video card data to hardware-info
+ - hardware listings should no longer contain special chars issue #43
+ - added filesystem information
+ - Update Report.pm
+ - added netowrk interface info per issue #37
+ - removed extra hash layer in networking section
+ - adding patches
+ - more patches
+ - patching again
+ - get_kit_info function no longer needs to parse ego output
+ - Re-wrote get_y_or_n
+ - Correct a hash key I accidentally made plural
+ - Remove JSON substitutions in get_filesystem_info()
+ - Translate block device arrayrefs to hashrefs
+ - Replaced ES module with the core module HTTP::Tiny for issue #42
+ - just a perltidy and remove extra lines
+ - Add --bytes (-b) to lsblk call to get byte sizes
+ - for issue #47 replaced array items with slot number hashes
+ - combined hardware information into a complete structure issue #47
+ - Update README.md
+ - Correct formatting error in `equery` output
+ - Rewrite report_time() with UTC everywhere
+ - Specify imported functions for `POSIX` module
+ - Date format correction
+ - Don't retrieve lspci output on module load
+ - Factor out arrayref transform into separate sub
+ - Correct a comment about traversal type
+ - Coerce numeric types for block device sizes
+ - Remove unneeded parens
+ - Replace `transform_es_arrayref` with simple method
+ - with code to reveal the response from ES
+ - Add trail comma to last line of Makefile.PL args
+ - Add binscript to Makefile.PL EXE_FILES
+ - Ignore Makefile.PL build artifacts
+ - Use magic #!perl shebang for binscript
+ - Ignore some `make` artifact files
+ - Remove `use lib` from binscript
+ - Add version, strict, and warnings to Makefile.PL
+ - Ignore built distribution tarballs
+ - Specify minimum Perl of v5.14
+ - Specify module dependencies in Makefile.PL
+ - Ignore old Makefiles
+ - Remove comment referring to removed module
+ - Add three more dependencies to Makefile.PL
+ - sending report now returns a URL to that data, also changed back the
+   shebang to normal
+ - Update README.md
+ - just fixing credits
+ - Add comments, examples for `report_time` formats
+ - Use English variable names throughout module
+ - Promote `Carp` import to package scope
+ - Realign `use` comments
+ - Remove unneeded sub exports
+ - Re-work get_all_installed_pkg()
+ - Add dependency on List::Util >=v1.33
+ - Add some HTTP error handling and output
+ - Add Getopt::Long with a --debug/-d flag
+ - Skip package DB dirs beginning with -MERGING-
+ - Lowercase a comment
+ - Refactor script actions with dispatch table
+ - added error section for issue #58
+ - Define a custom User-Agent for the HTTP submit
+ - Adjust hash structure and error-handling
+ - adjusting new function
+ - test commit
+ - Re-work get_all_installed_pkg, etc. for release
+ - switch to elk instead of elk2
+ - tweaking data structure for original ES
+ - Correct documented config file path
+ - Correct and rewrap a mis-wrapped README paragraph
+ - Correct another mis-wrapped README paragraph
+ - Mention -d/--debug option in README.md
+ - Trivial comment fixes
+ - Make comment refs to `lspci` calls consistent
+ - Correct comment description of short date format
+ - Update Report.pm
+ - Update funtoo-report
+
+1.3	2018-02-18
+
+ - Delete README.md
+ - Create README.txt
+ - Update Report.pm
+ - Update report
+ - Added UUID, fixed config file fail safes
+ - Fix profiles to remove shortname key
+ - fixes cpu-info to show siblings instead of cores, numerical instead
+   of strings
+ - removed /n from id
+ - Added function to send the report, also shortened the config file
+   algorythm
+ - no change
+ - set cpu-info to count processors from file
+ - now reporting world file again
+ - datestamp is back
+ - added versioning and removed trailing space from UUID
+ - changing timestamp to epochtime in seconds
+ - Just added some notes to make it easier to follow
+ - added installed packages, added conf file generator, also chassis
+   info
+ - Rename README.txt to README.md
+ - Update README.md
+ - Update README.md
+ - Update README.md
+ - Added the full list of chassis possibilities from www.dmtf.org
+   official provider of these docs
+ - bump version to 1.2
+ - update readme with install instructions for now
+ - Update README.md
+ - change layout of the project and add Funtoo:: before the Report
+   module
+ - Update Report.pm
+ - add Makefile.PL and MANIFEST
+ - commenting out use of lib folder as we will have it in our perl
+   install
+ - forgot to rename file
+ - update manifest
+ - Updating README and preparing for release
+ - update readme
+ - changed help
+ - moved UUID to the body of the report and changed ES header to report
+   a blank string as _ID
+ - Added credits in comments
+ - Create License
+ - add LICENSE file once it gets added to the repo
+ - update Readme
+ - Addressed issue #31, added dynamic index name by date and fancy date
+   format for the report body
+ - Update README.md
+ - Update funtoo-report
+ - added leading 0 to timestamp
+ - fix for offset when GMT+x
+ - Update funtoo-report
+ - remove CPAN ref
+ - fix typo in glibc version

--- a/Changes
+++ b/Changes
@@ -14,7 +14,6 @@ Revision history for Funtoo-Report
  - Simplify an interpolated string
  - Adjust formatting and indent for a comment
  - Use actual undef, not string "undef" for hash work
- - Adjust formatting and indent for a comment
  - Add $VERSION to funtoo-reporter script
  - Add explicit package to funtoo-reporter script
  - Switch to development version and ELK settings
@@ -30,9 +29,7 @@ Revision history for Funtoo-Report
  - Remove autodie from Makefile.PL dependencies list
  - creating daily indexing for ES
  - Remove POSIX dependency
- - Perl::Tidy run over funtoo-report
  - Add 'version' arg to print script/module versions
- - Perl::Tidy run
  - Short-circuit submission if UUID is obviously bad
  - Mention required version for List::Util in POD
  - Added a function to check latest version in GIT
@@ -44,7 +41,6 @@ Revision history for Funtoo-Report
  - added version in index string
  - formatting date string for index
  - Removed the version check function and remnants
- - perltidy
  - Update Report.pm
  - Adjusted USAGE and finished Getopt integration
  - Remove previous cmd line with outdate opt format
@@ -53,7 +49,6 @@ Revision history for Funtoo-Report
  - Adjusted short option for config update in anticipation of
    alternative configuration option
  - Changed hard-coded http to https and bumped the version
- - Bump version in the other three places
  - Correct short letter for --config-update option
  - Update README.md to reflect new options syntax
  - Correct a spelling error in README.md
@@ -69,17 +64,12 @@ Revision history for Funtoo-Report
  - Update protocol URL in module POD
  - Combine dummy dev hash creation in get_net_info()
  - Combine hashref declaration in get_net_info()
- - Bump version number in module POD
  - Correct short --list-config: -n to -l
  - Add HTTP::Tiny HTTPS depends to module POD
  - Create .travis.yml
  - Alternative form of get_all_installed_pkg()
  - Removing apparently nonsensical line
- - Merge branch 'alternative-getall' of
-   https://github.com/haxmeister/funtoo-reporter into alternative-getall
- - Create .travis.yml
  - Add a separate world-info section
- - Preparing to merge to develop
  - Initial work on restructuring filesystem info
  - added device-count
  - adjusted to coerce numbers for filesystem sizes
@@ -87,35 +77,23 @@ Revision history for Funtoo-Report
  - minor device count modification #94
  - switched to a datastructure of totals
  - adapting for null fstypes found on my container
- - tweaks
  - cleaned up, good candidate issue #94
  - failures from null values fixed finally?
  - added size and count of fstypes #94
- - tweaks
- - tweaks again
- - Create .travis.yml
  - Convert filesystem and memory to GB
  - Add +=0 to coerce the new values to pure numbers instead of strings
  - #94 with renamed unreported and swapspace
- - Merge branch 'feature/filesystems' of
-   https://github.com/haxmeister/funtoo-reporter into
-   feature/filesystems
  - #94 restoring GB in meminfo
- - Preparing to merge to develop
  - changes in options
- - Minor corrections + perltidy
  - patching error from null fstypes that are not children
  - patch missing sigil
- - Ran perltidy
- - Update Report.pm
- - Adding first try to implement #102 - README.md and	POD version
+ - Adding first try to implement #102 - README.md and POD version
    update working - not working: bumping our $VERSION, please fix
  - #105 now recursive, should follow children and avoid null errors
  - Changed to pure shell, regexes working
  - Correcting usage to imply mandatory arguments
  - picking up nulls
  - Formatting for GB
- - Added support for alpha/beta/rc stages alongside normal bumps
  - Skips virtual devices as requested by #106
  - Add "describe" option as per request in #102
  - Fixing '.' in version output.
@@ -125,25 +103,19 @@ Revision history for Funtoo-Report
  - Updating documentation that references the ES URL
  - Updated URLs to make merging with develop easier
  - #107 field limit fix
- - #107 repairing merge mess
  - Add comment with version to config as per #112
  - set verbose output and clean up
- - Update Report.pm
  - Revert "Update Report.pm"
- - Update Report.pm
  - adding POD for new function
  - Perltidy + start of additional documentation
- - Bumping the version to 3.0.0 in preparation for new major release
 
 2.0.1	2018-03-21
 
  - Switch to HTTPS URL, add Makefile.PL depend spec
- - Bump version number
 
 2.0.0	2018-03-17
 
  - Normalized error-handling
- - Ran Report.pm and funtoo-report through perltidy
  - Removing old instance of autodie
  - Changed error-reporting to a flattened array
  - Added line numbers to @errors
@@ -157,23 +129,18 @@ Revision history for Funtoo-Report
    /etc/funtoo-report.conf
  - Update funtoo-report
  - simple error fix
- - Now shows sound card data issue #36 and ran perltidy
  - added video card data to hardware-info
  - hardware listings should no longer contain special chars issue #43
  - added filesystem information
  - Update Report.pm
  - added netowrk interface info per issue #37
  - removed extra hash layer in networking section
- - adding patches
- - more patches
- - patching again
  - get_kit_info function no longer needs to parse ego output
  - Re-wrote get_y_or_n
  - Correct a hash key I accidentally made plural
  - Remove JSON substitutions in get_filesystem_info()
  - Translate block device arrayrefs to hashrefs
  - Replaced ES module with the core module HTTP::Tiny for issue #42
- - just a perltidy and remove extra lines
  - Add --bytes (-b) to lsblk call to get byte sizes
  - for issue #47 replaced array items with slot number hashes
  - combined hardware information into a complete structure issue #47
@@ -204,7 +171,6 @@ Revision history for Funtoo-Report
  - Add three more dependencies to Makefile.PL
  - sending report now returns a URL to that data, also changed back the
    shebang to normal
- - Update README.md
  - just fixing credits
  - Add comments, examples for `report_time` formats
  - Use English variable names throughout module
@@ -222,7 +188,6 @@ Revision history for Funtoo-Report
  - Define a custom User-Agent for the HTTP submit
  - Adjust hash structure and error-handling
  - adjusting new function
- - test commit
  - Re-work get_all_installed_pkg, etc. for release
  - switch to elk instead of elk2
  - tweaking data structure for original ES
@@ -233,8 +198,6 @@ Revision history for Funtoo-Report
  - Trivial comment fixes
  - Make comment refs to `lspci` calls consistent
  - Correct comment description of short date format
- - Update Report.pm
- - Update funtoo-report
 
 1.3	2018-02-18
 
@@ -260,16 +223,11 @@ Revision history for Funtoo-Report
    info
  - Rename README.txt to README.md
  - Update README.md
- - Update README.md
- - Update README.md
  - Added the full list of chassis possibilities from www.dmtf.org
    official provider of these docs
- - bump version to 1.2
  - update readme with install instructions for now
- - Update README.md
  - change layout of the project and add Funtoo:: before the Report
    module
- - Update Report.pm
  - add Makefile.PL and MANIFEST
  - commenting out use of lib folder as we will have it in our perl
    install
@@ -286,10 +244,8 @@ Revision history for Funtoo-Report
  - update Readme
  - Addressed issue #31, added dynamic index name by date and fancy date
    format for the report body
- - Update README.md
  - Update funtoo-report
  - added leading 0 to timestamp
  - fix for offset when GMT+x
- - Update funtoo-report
  - remove CPAN ref
  - fix typo in glibc version

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,3 +1,4 @@
+Changes
 Makefile.PL
 MANIFEST
 README.md


### PR DESCRIPTION
This is just generated with some judicious `git log` and some text filtering, but I think it's a workable start for a `Changelog`. @palica or anyone else should feel free to filter this down to make it contain less developer-specific noise if they deem it necessary.

This addresses issue #122, at least in part.