### PR TITLE
Add configuration check and pre-emptive bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Funtoo-Report - v3.0.0 ![CI build test badge](https://api.travis-ci.org/haxmeister/funtoo-reporter.svg?branch=master "Build test badge")
+# Funtoo-Report - v3.1.0-beta ![CI build test badge](https://api.travis-ci.org/haxmeister/funtoo-reporter.svg?branch=develop "Build test badge")
 
 ###### Anonymous reporting tool for Funtoo Linux
 

--- a/funtoo-report
+++ b/funtoo-report
@@ -23,7 +23,7 @@ use Funtoo::Report;                             #GIT
 use HTTP::Tiny;                                 #core
 use Pod::Usage;                                 #core
 
-our $VERSION = '3.0.0';
+our $VERSION = '3.1.0-beta';
 
 my %es_config = (
     node  => 'https://es.host.funtoo.org:9200',

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -165,26 +165,30 @@ sub user_config {
                 next;
             }
 
-            # split the line on the colon
-            # left side becomes a key, right side a value
-            # then check that it's a known option...
+           # split the line on the colon
+           # left side becomes a key, right side a value
+           # then, unless it's a new config, check that it's a known option...
             elsif ($line) {
                 my ( $key, $value ) = split /\s*:\s*/msx, $line;
-                if ( any { $_ eq $key } @known_options ) {
-                    $hash{$key} = $value;
-                }
-                else {
-                    die
-                        "Invalid configuration detected in '$config_file': key '$key' is not a valid option. Consider running '$PROGRAM_NAME --update-config'.\n";
+                if ( !$args ) {
+                    if ( any { $_ eq $key } @known_options ) {
+                        $hash{$key} = $value;
+                    }
+                    else {
+                        die
+                            "Invalid configuration detected in '$config_file': key '$key' is not a valid option. Consider running '$PROGRAM_NAME --update-config'.\n";
+                    }
                 }
             }
         }
 
         # ...and that all the options are present
-        for my $option (@known_options) {
-            if ( !exists $hash{$option} ) {
-                die
-                    "Missing essential configuration option ($option) in '$config_file'. Consider running '$PROGRAM_NAME --update-config.\n";
+        if ( !$args ) {
+            for my $option (@known_options) {
+                if ( !exists $hash{$option} ) {
+                    die
+                        "Missing essential configuration option ($option) in '$config_file'. Consider running '$PROGRAM_NAME --update-config.\n";
+                }
             }
         }
     }

--- a/lib/Funtoo/Report.pm
+++ b/lib/Funtoo/Report.pm
@@ -15,7 +15,7 @@ use Term::ANSIColor;               #core
 use Time::Piece;                   #core
 use Time::HiRes qw(gettimeofday);                   #core
 
-our $VERSION = '3.1.0-alpha';
+our $VERSION = '3.1.0-beta';
 
 ### getting some initialization done:
 our $config_file = '/etc/funtoo-report.conf';
@@ -153,6 +153,10 @@ sub user_config {
     if ( open( my $fh, '<:encoding(UTF-8)', $config_file ) ) {
         my @lines = <$fh>;
         close $fh;
+
+        my @known_options
+            = qw(UUID boot-dir-info hardware-info installed-pkgs kernel-info kit-info profile-info);
+
         foreach my $line (@lines) {
             chomp $line;
 
@@ -163,9 +167,24 @@ sub user_config {
 
             # split the line on the colon
             # left side becomes a key, right side a value
+            # then check that it's a known option...
             elsif ($line) {
                 my ( $key, $value ) = split /\s*:\s*/msx, $line;
-                $hash{$key} = $value;
+                if ( any { $_ eq $key } @known_options ) {
+                    $hash{$key} = $value;
+                }
+                else {
+                    die
+                        "Invalid configuration detected in '$config_file': key '$key' is not a valid option. Consider running '$PROGRAM_NAME --update-config'.\n";
+                }
+            }
+        }
+
+        # ...and that all the options are present
+        for my $option (@known_options) {
+            if ( !exists $hash{$option} ) {
+                die
+                    "Missing essential configuration option ($option) in '$config_file'. Consider running '$PROGRAM_NAME --update-config.\n";
             }
         }
     }
@@ -1059,7 +1078,7 @@ Funtoo::Report - Functions for retrieving and sending data on Funtoo Linux
 
 =head1 VERSION
 
-Version 3.0.0
+Version 3.1.0-beta
 
 =head1 DESCRIPTION
 
@@ -1206,7 +1225,8 @@ the configuration. Can exit with failure if unable to read the config file.
 =item C<user_config>
 
 Parses the config file, returning the results as a hash. Can exit if unable to
-read the config file.
+read the config file, if the detected options are not in the list of known-good
+options, or if known-good options are misisng.
 
 =item C<version>
 


### PR DESCRIPTION
-Pre-emptively bumped the version number to 3.1.0-beta since I expect
that will be in develop by the time this is merged.
-Added a configuration checker that ensures no unwanted keys are present
and that wanted keys are accounted for. Does nothing about values at
this point.
-Updated the relevant POD mentioning the above.